### PR TITLE
Use state instead of Settings

### DIFF
--- a/pyiron_gpl/pacemaker/pacemaker.py
+++ b/pyiron_gpl/pacemaker/pacemaker.py
@@ -11,11 +11,9 @@ import ruamel.yaml as yaml
 
 from shutil import copyfile
 
-from pyiron_base import GenericJob, DataContainer, ImportAlarm, Settings
-from pyiron_contrib.atomistic.atomistics.job.trainingcontainer import TrainingContainer
+from pyiron_base import GenericJob, DataContainer, ImportAlarm
+from pyiron_contrib.atomistics.atomistics.job.trainingcontainer import TrainingContainer
 
-
-s = Settings()
 
 try:
     from pyace import BBasisConfiguration, ACEBBasisSet


### PR DESCRIPTION
A surprising amount of the time that just meant getting rid of the Settings import, as it was unused. I also snuck in a couple other unused import removals and some encoding info additions here and there, depending on the repo.